### PR TITLE
Restrict public access to aggregator queries and introspection for now

### DIFF
--- a/graphql/config.yaml
+++ b/graphql/config.yaml
@@ -15,3 +15,13 @@ configurationset:
           name: flipside_config
           api_key: STEPZEN_FLIPSIDE_API_KEY
           stepzen.queryextensionguard: true
+access:
+    policies:
+        - type: Query
+          rules:
+              - condition: true
+                name: public fields
+                fields: [collection, account]
+              - condition: true
+                name: introspection
+                fields: [__type, __schema, __typename, _service]


### PR DESCRIPTION
Disabled API access in Stellate so it respects the field policies from stepzen config, this makes only the `account` and `collection` queries available to the general public for now.

Closes #3 